### PR TITLE
add global_planner and dwa_local_planner to ic120_navigation/package.xml

### DIFF
--- a/ic120_navigation/package.xml
+++ b/ic120_navigation/package.xml
@@ -56,7 +56,9 @@
   <build_depend>geometry_msgs</build_depend>
   <depend>robot_localization</depend>
   <depend>move_base</depend>
-
+  <depend>global_planner</depend>
+  <depend>dwa_local_planner</depend>
+  
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
docker上で問題なくic120_standby.launchが実行され、Unityシミュレータと連携することを確認しました